### PR TITLE
README.md `npm i`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Template repository for creating Pear applings.
 Replace the placeholders in [`CMakeLists.txt`](CMakeLists.txt) with appropriate values and then build the appling using <https://github.com/holepunchto/bare-make>:
 
 ```console
+npm i
 bare-make generate
 bare-make build
 ```


### PR DESCRIPTION
I forgot to `npm i` and the CMake error was not too obvious to me what was wrong so I suggest adding it to README

<img width="803" height="380" alt="image" src="https://github.com/user-attachments/assets/3c0e166b-35fd-4954-b2ff-7b0b19fda368" />
